### PR TITLE
[SYCL] Re-use OpenCL sampler in SYCL mode

### DIFF
--- a/buildbot/dependency.sh
+++ b/buildbot/dependency.sh
@@ -76,5 +76,8 @@ else
 fi
 
 cd ${BUILD_DIR}/OpenCL-ICD-Loader
+mkdir build
+cd build
+cmake ..
 make C_INCLUDE_PATH=${OPENCL_HEADERS}
 exit_if_err $? "failed to build OpenCL-ICD-Loader"

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -1283,7 +1283,7 @@ void ASTContext::InitBuiltinTypes(const TargetInfo &Target,
   InitBuiltinType(ObjCBuiltinClassTy, BuiltinType::ObjCClass);
   InitBuiltinType(ObjCBuiltinSelTy, BuiltinType::ObjCSel);
 
-  if (LangOpts.OpenCL) {
+  if (LangOpts.OpenCL || LangOpts.SYCLIsDevice) {
 #define IMAGE_TYPE(ImgType, Id, SingletonId, Access, Suffix) \
     InitBuiltinType(SingletonId, BuiltinType::Id);
 #include "clang/Basic/OpenCLImageTypes.def"

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -129,7 +129,7 @@ CodeGenModule::CodeGenModule(ASTContext &C, const HeaderSearchOptions &HSO,
 
   if (LangOpts.ObjC)
     createObjCRuntime();
-  if (LangOpts.OpenCL)
+  if (LangOpts.OpenCL || LangOpts.SYCLIsDevice)
     createOpenCLRuntime();
   if (LangOpts.OpenMP)
     createOpenMPRuntime();

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3420,17 +3420,18 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   assert(Inputs.size() >= 1 && "Must have at least one input.");
   // CUDA/HIP compilation may have multiple inputs (source file + results of
   // device-side compilations). OpenMP and SYCL device jobs also take the host
-  // IR as a second input. All other jobs are expected to have exactly one
-  // include as part of the module. All other jobs are expected to have exactly
-  // one input.
+  // IR as a second input. Module precompilation accepts a list of header files
+  // to include as part of the module. All other jobs are expected to have
+  // exactly one input.
   bool IsCuda = JA.isOffloading(Action::OFK_Cuda);
   bool IsHIP = JA.isOffloading(Action::OFK_HIP);
   bool IsOpenMPDevice = JA.isDeviceOffloading(Action::OFK_OpenMP);
   bool IsSYCLOffloadDevice = JA.isDeviceOffloading(Action::OFK_SYCL);
   bool IsSYCL = JA.isOffloading(Action::OFK_SYCL);
   bool IsHeaderModulePrecompile = isa<HeaderModulePrecompileJobAction>(JA);
-  assert((IsCuda || IsHIP || (IsOpenMPDevice && Inputs.size() == 2) ||
-         IsSYCL || Inputs.size() == 1) && "Unable to handle multiple inputs.");
+  assert((IsCuda || IsHIP || (IsOpenMPDevice && Inputs.size() == 2) || IsSYCL ||
+          IsHeaderModulePrecompile || Inputs.size() == 1) &&
+         "Unable to handle multiple inputs.");
 
   // A header module compilation doesn't have a main input file, so invent a
   // fake one as a placeholder.

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -244,7 +244,7 @@ void Sema::Initialize() {
     if (IdResolver.begin(Class) == IdResolver.end())
       PushOnScopeChains(Context.getObjCClassDecl(), TUScope);
 
-    // Create the built-in forward declaratino for 'Protocol'.
+    // Create the built-in forward declaration for 'Protocol'.
     DeclarationName Protocol = &Context.Idents.get("Protocol");
     if (IdResolver.begin(Protocol) == IdResolver.end())
       PushOnScopeChains(Context.getObjCProtocolDecl(), TUScope);
@@ -267,6 +267,9 @@ void Sema::Initialize() {
 
   // Initialize predefined OpenCL types and supported extensions and (optional)
   // core features.
+  if (getLangOpts().SYCLIsDevice) {
+    addImplicitTypedef("__ocl_sampler_t", Context.OCLSamplerTy);
+  }
   if (getLangOpts().OpenCL) {
     getOpenCLOptions().addSupport(
         Context.getTargetInfo().getSupportedOpenCLOpts());

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -6327,6 +6327,26 @@ NamedDecl *Sema::ActOnVariableDeclarator(
     return nullptr;
   }
 
+  if (R->isSamplerT()) {
+    // OpenCL v1.2 s6.9.b p4:
+    // The sampler type cannot be used with the __local and __global address
+    // space qualifiers.
+    if (R.getAddressSpace() == LangAS::opencl_local ||
+        R.getAddressSpace() == LangAS::opencl_global) {
+      Diag(D.getIdentifierLoc(), diag::err_wrong_sampler_addressspace);
+    }
+
+    // OpenCL v1.2 s6.12.14.1:
+    // A global sampler must be declared with either the constant address
+    // space qualifier or with the const qualifier.
+    if (DC->isTranslationUnit() &&
+        !(R.getAddressSpace() == LangAS::opencl_constant ||
+          R.isConstQualified())) {
+      Diag(D.getIdentifierLoc(), diag::err_opencl_nonconst_global_sampler);
+      D.setInvalidType();
+    }
+  }
+
   if (getLangOpts().OpenCL) {
     // OpenCL v2.0 s6.9.b - Image type can only be used as a function argument.
     // OpenCL v2.0 s6.13.16.1 - Pipe type can only be used as a function
@@ -6368,26 +6388,6 @@ NamedDecl *Sema::ActOnVariableDeclarator(
       // half array type (unless the cl_khr_fp16 extension is enabled).
       if (Context.getBaseElementType(R)->isHalfType()) {
         Diag(D.getIdentifierLoc(), diag::err_opencl_half_declaration) << R;
-        D.setInvalidType();
-      }
-    }
-
-    if (R->isSamplerT()) {
-      // OpenCL v1.2 s6.9.b p4:
-      // The sampler type cannot be used with the __local and __global address
-      // space qualifiers.
-      if (R.getAddressSpace() == LangAS::opencl_local ||
-          R.getAddressSpace() == LangAS::opencl_global) {
-        Diag(D.getIdentifierLoc(), diag::err_wrong_sampler_addressspace);
-      }
-
-      // OpenCL v1.2 s6.12.14.1:
-      // A global sampler must be declared with either the constant address
-      // space qualifier or with the const qualifier.
-      if (DC->isTranslationUnit() &&
-          !(R.getAddressSpace() == LangAS::opencl_constant ||
-          R.isConstQualified())) {
-        Diag(D.getIdentifierLoc(), diag::err_opencl_nonconst_global_sampler);
         D.setInvalidType();
       }
     }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12404,7 +12404,7 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
   if (!LHS.isUsable() || !RHS.isUsable())
     return ExprError();
 
-  if (getLangOpts().OpenCL) {
+  if (getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) {
     QualType LHSTy = LHSExpr->getType();
     QualType RHSTy = RHSExpr->getType();
     // OpenCLC v2.0 s6.13.11.1 allows atomic variables to be initialized by

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12404,7 +12404,7 @@ ExprResult Sema::CreateBuiltinBinOp(SourceLocation OpLoc,
   if (!LHS.isUsable() || !RHS.isUsable())
     return ExprError();
 
-  if (getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) {
+  if (getLangOpts().OpenCL) {
     QualType LHSTy = LHSExpr->getType();
     QualType RHSTy = RHSExpr->getType();
     // OpenCLC v2.0 s6.13.11.1 allows atomic variables to be initialized by
@@ -13019,7 +13019,7 @@ ExprResult Sema::CreateBuiltinUnaryOp(SourceLocation OpLoc,
   bool CanOverflow = false;
 
   bool ConvertHalfVec = false;
-  if (getLangOpts().OpenCL) {
+  if (getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) {
     QualType Ty = InputExpr->getType();
     // The only legal unary operation for atomics is '&'.
     if ((Opc != UO_AddrOf && Ty->isAtomicType()) ||

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5305,9 +5305,9 @@ static bool TryOCLSamplerInitialization(Sema &S,
                                         InitializationSequence &Sequence,
                                         QualType DestType,
                                         Expr *Initializer) {
-  if (!S.getLangOpts().OpenCL || !DestType->isSamplerT() ||
+  if (!DestType->isSamplerT() ||
       (!Initializer->isIntegerConstantExpr(S.Context) &&
-      !Initializer->getType()->isSamplerT()))
+       !Initializer->getType()->isSamplerT()))
     return false;
 
   Sequence.AddOCLSamplerInitStep(DestType);

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -5620,6 +5620,9 @@ void InitializationSequence::InitializeFrom(Sema &S,
   bool allowObjCWritebackConversion = S.getLangOpts().ObjCAutoRefCount &&
          Entity.isParameterKind();
 
+  if (TryOCLSamplerInitialization(S, *this, DestType, Initializer))
+    return;
+
   // We're at the end of the line for C: it's either a write-back conversion
   // or it's a C assignment. There's no need to check anything else.
   if (!S.getLangOpts().CPlusPlus) {
@@ -5628,9 +5631,6 @@ void InitializationSequence::InitializeFrom(Sema &S,
         tryObjCWritebackConversion(S, *this, Entity, Initializer)) {
       return;
     }
-
-    if (TryOCLSamplerInitialization(S, *this, DestType, Initializer))
-      return;
 
     if (TryOCLZeroOpaqueTypeInitialization(S, *this, DestType, Initializer))
       return;

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -2303,7 +2303,7 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
   // OpenCL v2.0 s6.12.5 - Arrays of blocks are not supported.
   // OpenCL v2.0 s6.16.13.1 - Arrays of pipe type are not supported.
   // OpenCL v2.0 s6.9.b - Arrays of image/sampler type are not supported.
-  if (getLangOpts().OpenCL) {
+  if (getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) {
     const QualType ArrType = Context.getBaseElementType(T);
     if (ArrType->isBlockPointerType() || ArrType->isPipeType() ||
         ArrType->isSamplerT() || ArrType->isImageType()) {
@@ -4389,7 +4389,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
       // OpenCL v2.0 s6.9b - Pointer to image/sampler cannot be used.
       // OpenCL v2.0 s6.13.16.1 - Pointer to pipe cannot be used.
       // OpenCL v2.0 s6.12.5 - Pointers to Blocks are not allowed.
-      if (LangOpts.OpenCL) {
+      if (LangOpts.OpenCL || LangOpts.SYCLIsDevice) {
         if (T->isImageType() || T->isSamplerT() || T->isPipeType() ||
             T->isBlockPointerType()) {
           S.Diag(D.getIdentifierLoc(), diag::err_opencl_pointer_to_type) << T;
@@ -4587,7 +4587,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         }
       }
 
-      if (LangOpts.OpenCL) {
+      if (LangOpts.OpenCL || LangOpts.SYCLIsDevice) {
         // OpenCL v2.0 s6.12.5 - A block cannot be the return value of a
         // function.
         if (T->isBlockPointerType() || T->isImageType() || T->isSamplerT() ||
@@ -4599,7 +4599,9 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
         // OpenCL doesn't support variadic functions and blocks
         // (s6.9.e and s6.12.5 OpenCL v2.0) except for printf.
         // We also allow here any toolchain reserved identifiers.
+        // FIXME: Use deferred diagnostics engine to skip host side issues.
         if (FTI.isVariadic &&
+            !LangOpts.SYCLIsDevice &&
             !(D.getIdentifier() &&
               ((D.getIdentifier()->getName() == "printf" &&
                 (LangOpts.OpenCLCPlusPlus || LangOpts.OpenCLVersion >= 120)) ||

--- a/clang/test/CodeGenSYCL/int_header1.cpp
+++ b/clang/test/CodeGenSYCL/int_header1.cpp
@@ -1,5 +1,4 @@
 // RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
-// RUN: %clang -I %S/Inputs --sycl -Xclang -fsycl-int-header=%t.h %s -c -o kernel.spv
 // RUN: FileCheck -input-file=%t.h %s
 
 // CHECK:template <> struct KernelInfo<class KernelName> {

--- a/clang/test/Driver/clang-offload-bundler.c
+++ b/clang/test/Driver/clang-offload-bundler.c
@@ -5,7 +5,7 @@
 // Generate all the types of files we can bundle.
 //
 // generate the emulated fat object:
-// RUN: %clangxx -O0 -target powerpc64le-ibm-linux-gnu -DEMULATE_FAT_OBJ %s -c -o %s.o
+// RUN: %clangxx -O0 -target powerpc64le-ibm-linux-gnu -DEMULATE_FAT_OBJ %s -c -o %t.2.o
 //
 // RUN: %clang -O0 -target powerpc64le-ibm-linux-gnu %s -E -o %t.i
 // RUN: %clangxx -O0 -target powerpc64le-ibm-linux-gnu -x c++ %s -E -o %t.ii
@@ -237,12 +237,12 @@
 // CK-OBJ-CMD: private constant [{{[0-9]+}} x i8] c"Content of device file 2{{.+}}", section "__CLANG_OFFLOAD_BUNDLE__openmp-x86_64-pc-linux-gnu"
 // CK-OBJ-CMD: clang{{(.exe)?}}" "-r" "-target" "powerpc64le-ibm-linux-gnu" "-o" "{{.+}}.o" "{{.+}}.o" "{{.+}}.bc" "-nostdlib"
 
-// RUN: clang-offload-bundler -type=o -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.res.o,%t.res.tgt1,%t.res.tgt2 -inputs=%s.o -unbundle
-// RUN: diff %s.o %t.res.o
+// RUN: clang-offload-bundler -type=o -targets=host-powerpc64le-ibm-linux-gnu,openmp-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.res.o,%t.res.tgt1,%t.res.tgt2 -inputs=%t.2.o -unbundle
+// RUN: diff %t.2.o %t.res.o
 // RUN: diff %t.tgt1 %t.res.tgt1
 // RUN: diff %t.tgt2 %t.res.tgt2
-// RUN: clang-offload-bundler -type=o -targets=openmp-powerpc64le-ibm-linux-gnu,host-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.res.tgt1,%t.res.o,%t.res.tgt2 -inputs=%s.o -unbundle
-// RUN: diff %s.o %t.res.o
+// RUN: clang-offload-bundler -type=o -targets=openmp-powerpc64le-ibm-linux-gnu,host-powerpc64le-ibm-linux-gnu,openmp-x86_64-pc-linux-gnu -outputs=%t.res.tgt1,%t.res.o,%t.res.tgt2 -inputs=%t.2.o -unbundle
+// RUN: diff %t.2.o %t.res.o
 // RUN: diff %t.tgt1 %t.res.tgt1
 // RUN: diff %t.tgt2 %t.res.tgt2
 

--- a/clang/test/SemaSYCL/sampler.cpp
+++ b/clang/test/SemaSYCL/sampler.cpp
@@ -19,7 +19,7 @@ int main() {
 // CHECK: FunctionDecl {{.*}}use_kernel_for_test 'void (__spirv::OpTypeSampler *)'
 //
 // Check parameters of the test kernel
-// CHECK: ParmVarDecl {{.*}} used _arg_m_Sampler '__spirv::OpTypeSampler *'
+// CHECK: ParmVarDecl {{.*}} used [[_arg_sampler:[0-9a-zA-Z_]+]] '__spirv::OpTypeSampler *'
 //
 // Check that sampler field of the test kernel object is initialized using __init method
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -30,4 +30,4 @@ int main() {
 // Check the parameters of __init method
 // CHECK-NEXT: ImplicitCastExpr {{.*}} '__spirv::OpTypeSampler *' <LValueToRValue>
 // CHECK-NEXT: ImplicitCastExpr {{.*}} '__spirv::OpTypeSampler *' lvalue <NoOp>
-// CHECK-NEXT: DeclRefExpr {{.*}} '__spirv::OpTypeSampler *' lvalue ParmVar {{.*}} '_arg_m_Sampler' '__spirv::OpTypeSampler
+// CHECK-NEXT: DeclRefExpr {{.*}} '__spirv::OpTypeSampler *' lvalue ParmVar {{.*}} '[[_arg_sampler]]' '__spirv::OpTypeSampler

--- a/clang/test/SemaSYCL/wrapped-accessor.cpp
+++ b/clang/test/SemaSYCL/wrapped-accessor.cpp
@@ -25,9 +25,9 @@ int main() {
 // Check parameters of the kernel
 // CHECK: ParmVarDecl {{.*}} used _arg_ 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >'
 // CHECK: ParmVarDecl {{.*}} used _arg_accessor '__global int *'
-// CHECK: ParmVarDecl {{.*}} used _arg_AccessRange 'range<1>':'cl::sycl::range<1>'
-// CHECK: ParmVarDecl {{.*}} used _arg_MemRange 'range<1>':'cl::sycl::range<1>'
-// CHECK: ParmVarDecl {{.*}} used _arg_Offset 'id<1>':'cl::sycl::id<1>'
+// CHECK: ParmVarDecl {{.*}} used [[_arg_AccessRange:[0-9a-zA-Z_]+]] 'range<1>':'cl::sycl::range<1>'
+// CHECK: ParmVarDecl {{.*}} used [[_arg_MemRange:[0-9a-zA-Z_]+]] 'range<1>':'cl::sycl::range<1>'
+// CHECK: ParmVarDecl {{.*}} used [[_arg_Offset:[0-9a-zA-Z_]+]] 'id<1>':'cl::sycl::id<1>'
 
 // Check that wrapper object itself is initialized with corresponding kernel argument using operator=
 // CHECK: BinaryOperator {{.*}} 'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >':'AccWrapper<cl::sycl::accessor<int, 1, cl::sycl::access::mode::read_write, cl::sycl::access::target::global_buffer, cl::sycl::access::placeholder::false_t> >' lvalue '='
@@ -52,8 +52,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' lvalue <NoOp>
 // CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_accessor' '__global int *'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'range<1>':'cl::sycl::range<1>' <NoOp>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'range<1>':'cl::sycl::range<1>' lvalue ParmVar {{.*}} '_arg_AccessRange' 'range<1>':'cl::sycl::range<1>'
+// CHECK-NEXT: DeclRefExpr {{.*}} 'range<1>':'cl::sycl::range<1>' lvalue ParmVar {{.*}} '[[_arg_AccessRange]]' 'range<1>':'cl::sycl::range<1>'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'range<1>':'cl::sycl::range<1>' <NoOp>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'range<1>':'cl::sycl::range<1>' lvalue ParmVar {{.*}} '_arg_MemRange' 'range<1>':'cl::sycl::range<1>'
+// CHECK-NEXT: DeclRefExpr {{.*}} 'range<1>':'cl::sycl::range<1>' lvalue ParmVar {{.*}} '[[_arg_MemRange]]' 'range<1>':'cl::sycl::range<1>'
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'id<1>':'cl::sycl::id<1>' <NoOp>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'id<1>':'cl::sycl::id<1>' lvalue ParmVar {{.*}} '_arg_Offset' 'id<1>':'cl::sycl::id<1>'
+// CHECK-NEXT: DeclRefExpr {{.*}} 'id<1>':'cl::sycl::id<1>' lvalue ParmVar {{.*}} '[[_arg_Offset]]' 'id<1>':'cl::sycl::id<1>'

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1035,6 +1035,9 @@ public:
   SPIRVId getMergeBlock() { return MergeBlock; }
   SPIRVId getContinueTarget() { return ContinueTarget; }
   SPIRVWord getLoopControl() { return LoopControl; }
+  std::vector<SPIRVWord> getLoopControlParameters() {
+    return LoopControlParameters;
+  }
 
   void setWordCount(SPIRVWord TheWordCount) override {
     SPIRVEntry::setWordCount(TheWordCount);

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -556,6 +556,7 @@ inline bool isValid(spv::Capability V) {
   case CapabilityNamedBarrier:
   case CapabilityPipeStorage:
   case CapabilityFPGAMemoryAttributesINTEL:
+  case CapabilityFPGALoopControlsINTEL:
     return true;
   default:
     return false;
@@ -1042,6 +1043,7 @@ inline bool isValidLoopControlMask(SPIRVWord Mask) {
   ValidMask |= LoopControlDontUnrollMask;
   ValidMask |= LoopControlDependencyInfiniteMask;
   ValidMask |= LoopControlDependencyLengthMask;
+  ValidMask |= LoopControlExtendedControlsMask;
 
   return (Mask & ~ValidMask) == 0;
 }

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -484,6 +484,7 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilitySubgroupAvcMotionEstimationChromaINTEL,
       "SubgroupAvcMotionEstimationChromaINTEL");
   add(CapabilityFPGAMemoryAttributesINTEL, "FPGAMemoryAttributesINTEL");
+  add(CapabilityFPGALoopControlsINTEL, "FPGALoopControlsINTEL");
 }
 SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 

--- a/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/spirv.hpp
@@ -484,6 +484,12 @@ enum LoopControlMask {
     LoopControlDontUnrollMask = 0x00000002,
     LoopControlDependencyInfiniteMask = 0x00000004,
     LoopControlDependencyLengthMask = 0x00000008,
+    LoopControlExtendedControlsMask = 0x80000000,
+};
+
+enum ExtendedControls {
+    InitiationIntervalINTEL = 5889,
+    MaxConcurrencyINTEL = 5890,
 };
 
 enum FunctionControlShift {
@@ -664,6 +670,7 @@ enum Capability {
   CapabilitySubgroupAvcMotionEstimationIntraINTEL = 5697,
   CapabilitySubgroupAvcMotionEstimationChromaINTEL = 5698,
   CapabilityFPGAMemoryAttributesINTEL = 5824,
+  CapabilityFPGALoopControlsINTEL = 5888,
   CapabilityMax = 0x7fffffff,
 };
 

--- a/llvm-spirv/test/transcoding/FPGALoopAttr.ll
+++ b/llvm-spirv/test/transcoding/FPGALoopAttr.ll
@@ -1,0 +1,178 @@
+; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; ModuleID = 'FPGALoopAttr.cl'
+source_filename = "FPGALoopAttr.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown-unknown"
+
+; CHECK-SPIRV: Function
+; Function Attrs: convergent noinline nounwind optnone
+define spir_kernel void @test_ivdep() #0 {
+entry:
+  %a = alloca [10 x i32], align 4
+  %i = alloca i32, align 4
+  %i1 = alloca i32, align 4
+  %i10 = alloca i32, align 4
+  %i19 = alloca i32, align 4
+  %i28 = alloca i32, align 4
+  store i32 0, i32* %i, align 4
+  br label %for.cond
+; CHECK-SPIRV: 4 LoopMerge {{[0-9]+}} {{[0-9]+}} 4
+; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+for.cond:                                         ; preds = %for.inc, %entry
+  %0 = load i32, i32* %i, align 4
+  %cmp = icmp ne i32 %0, 10
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %1 = load i32, i32* %i, align 4
+  %idxprom = sext i32 %1 to i64
+  %arrayidx = getelementptr inbounds [10 x i32], [10 x i32]* %a, i64 0, i64 %idxprom
+  store i32 0, i32* %arrayidx, align 4
+  br label %for.inc
+
+for.inc:                                          ; preds = %for.body
+  %2 = load i32, i32* %i, align 4
+  %inc = add nsw i32 %2, 1
+  store i32 %inc, i32* %i, align 4
+  br label %for.cond, !llvm.loop !3
+
+for.end:                                          ; preds = %for.cond
+  store i32 0, i32* %i1, align 4
+  br label %for.cond2
+
+; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 8 2
+; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+for.cond2:                                        ; preds = %for.inc7, %for.end
+  %3 = load i32, i32* %i1, align 4
+  %cmp3 = icmp ne i32 %3, 10
+  br i1 %cmp3, label %for.body4, label %for.end9
+
+for.body4:                                        ; preds = %for.cond2
+  %4 = load i32, i32* %i1, align 4
+  %idxprom5 = sext i32 %4 to i64
+  %arrayidx6 = getelementptr inbounds [10 x i32], [10 x i32]* %a, i64 0, i64 %idxprom5
+  store i32 0, i32* %arrayidx6, align 4
+  br label %for.inc7
+
+for.inc7:                                         ; preds = %for.body4
+  %5 = load i32, i32* %i1, align 4
+  %inc8 = add nsw i32 %5, 1
+  store i32 %inc8, i32* %i1, align 4
+  br label %for.cond2, !llvm.loop !5
+
+for.end9:                                         ; preds = %for.cond2
+  store i32 0, i32* %i10, align 4
+  br label %for.cond11
+
+; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5889 2
+; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+for.cond11:                                       ; preds = %for.inc16, %for.end9
+  %6 = load i32, i32* %i10, align 4
+  %cmp12 = icmp ne i32 %6, 10
+  br i1 %cmp12, label %for.body13, label %for.end18
+
+for.body13:                                       ; preds = %for.cond11
+  %7 = load i32, i32* %i10, align 4
+  %idxprom14 = sext i32 %7 to i64
+  %arrayidx15 = getelementptr inbounds [10 x i32], [10 x i32]* %a, i64 0, i64 %idxprom14
+  store i32 0, i32* %arrayidx15, align 4
+  br label %for.inc16
+
+for.inc16:                                        ; preds = %for.body13
+  %8 = load i32, i32* %i10, align 4
+  %inc17 = add nsw i32 %8, 1
+  store i32 %inc17, i32* %i10, align 4
+  br label %for.cond11, !llvm.loop !7
+
+for.end18:                                        ; preds = %for.cond11
+  store i32 0, i32* %i19, align 4
+  br label %for.cond20
+
+; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5890 2
+; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+for.cond20:                                       ; preds = %for.inc25, %for.end18
+  %9 = load i32, i32* %i19, align 4
+  %cmp21 = icmp ne i32 %9, 10
+  br i1 %cmp21, label %for.body22, label %for.end27
+
+for.body22:                                       ; preds = %for.cond20
+  %10 = load i32, i32* %i19, align 4
+  %idxprom23 = sext i32 %10 to i64
+  %arrayidx24 = getelementptr inbounds [10 x i32], [10 x i32]* %a, i64 0, i64 %idxprom23
+  store i32 0, i32* %arrayidx24, align 4
+  br label %for.inc25
+
+for.inc25:                                        ; preds = %for.body22
+  %11 = load i32, i32* %i19, align 4
+  %inc26 = add nsw i32 %11, 1
+  store i32 %inc26, i32* %i19, align 4
+  br label %for.cond20, !llvm.loop !9
+
+for.end27:                                        ; preds = %for.cond20
+  store i32 0, i32* %i28, align 4
+  br label %for.cond29
+
+; CHECK-SPIRV: 8 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5889 2 5890 2
+; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+for.cond29:                                       ; preds = %for.inc34, %for.end27
+  %12 = load i32, i32* %i28, align 4
+  %cmp30 = icmp ne i32 %12, 10
+  br i1 %cmp30, label %for.body31, label %for.end36
+
+for.body31:                                       ; preds = %for.cond29
+  %13 = load i32, i32* %i28, align 4
+  %idxprom32 = sext i32 %13 to i64
+  %arrayidx33 = getelementptr inbounds [10 x i32], [10 x i32]* %a, i64 0, i64 %idxprom32
+  store i32 0, i32* %arrayidx33, align 4
+  br label %for.inc34
+
+for.inc34:                                        ; preds = %for.body31
+  %14 = load i32, i32* %i28, align 4
+  %inc35 = add nsw i32 %14, 1
+  store i32 %inc35, i32* %i28, align 4
+  br label %for.cond29, !llvm.loop !11
+
+for.end36:                                        ; preds = %for.cond29
+  ret void
+}
+
+attributes #0 = { convergent noinline nounwind optnone "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!3 = distinct !{!3, !4}
+!4 = !{!"llvm.loop.ivdep.enable"}
+!5 = distinct !{!5, !6}
+!6 = !{!"llvm.loop.ivdep.safelen", i32 2}
+!7 = distinct !{!7, !8}
+!8 = !{!"llvm.loop.ii.count", i32 2}
+!9 = distinct !{!9, !10}
+!10 = !{!"llvm.loop.max_concurrency.count", i32 2}
+!11 = distinct !{!11, !8, !10}
+
+; CHECK-LLVM: br i1 %cmp, label %for.body, label %for.end, !llvm.loop ![[MD_A:[0-9]+]]
+; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_B:[0-9]+]]
+; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_C:[0-9]+]]
+; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_D:[0-9]+]]
+; CHECK-LLVM: br i1 %cmp{{[0-9]+}}, label %for.body{{[0-9]+}}, label %for.end{{[0-9]+}}, !llvm.loop ![[MD_E:[0-9]+]]
+
+; CHECK-LLVM: ![[MD_A]] = distinct !{![[MD_A]], ![[MD_ivdep_enable:[0-9]+]]}
+; CHECK-LLVM: ![[MD_ivdep_enable]] = !{!"llvm.loop.ivdep.enable"}
+; CHECK-LLVM: ![[MD_B]] = distinct !{![[MD_B]], ![[MD_ivdep:[0-9]+]]}
+; CHECK-LLVM: ![[MD_ivdep]] = !{!"llvm.loop.ivdep.safelen", i32 2}
+; CHECK-LLVM: ![[MD_C]] = distinct !{![[MD_C]], ![[MD_ii:[0-9]+]]}
+; CHECK-LLVM: ![[MD_ii]] = !{!"llvm.loop.ii.count", i32 2}
+; CHECK-LLVM: ![[MD_D]] = distinct !{![[MD_D]], ![[MD_max_concurrency:[0-9]+]]}
+; CHECK-LLVM: ![[MD_max_concurrency]] = !{!"llvm.loop.max_concurrency.count", i32 2}
+; CHECK-LLVM: ![[MD_E]] = distinct !{![[MD_E]], ![[MD_ii:[0-9]+]], ![[MD_max_concurrency:[0-9]+]]}

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -60,15 +60,16 @@ endif()
 if( NOT OpenCL_LIBRARIES )
   message("OpenCL_LIBRARIES is missed. Try to build from GitHub sources.")
   set(OpenCL_LIBRARIES "${LLVM_LIBRARY_OUTPUT_INTDIR}/libOpenCL.so")
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/icd_build)
   ExternalProject_Add(ocl-icd
     GIT_REPOSITORY    https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
     GIT_TAG           origin/master
     SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/icd"
-    CONFIGURE_COMMAND ""
-    BUILD_IN_SOURCE   TRUE
+    BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/icd_build"
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} "${CMAKE_CURRENT_BINARY_DIR}/OpenCL/icd" -DCMAKE_INSTALL_PREFIX=${LLVM_BINARY_DIR}
     BUILD_COMMAND     make C_INCLUDE_PATH=${CMAKE_CURRENT_BINARY_DIR}/OpenCL/inc
-    INSTALL_COMMAND   ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_BINARY_DIR}/OpenCL/icd/build ${LLVM_LIBRARY_OUTPUT_INTDIR}
-    STEP_TARGETS      build,install
+    INSTALL_COMMAND   make install 
+    STEP_TARGETS      configure,build,install
     DEPENDS           ocl-headers
   )
 else()

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -182,11 +182,10 @@ add_custom_target( sycl-toolchain
 
 set_target_properties("${SYCLLibrary}" PROPERTIES LINKER_LANGUAGE CXX)
 
-# Workaround for bug in GCC version 5.
+# Workaround for bug in GCC version 5 and higher.
 # More information https://bugs.launchpad.net/ubuntu/+source/gcc-5/+bug/1568899
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0 AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
   target_link_libraries("${SYCLLibrary}" gcc_s gcc)
 endif()
 

--- a/sycl/doc/SYCL_compiler_and_runtime_design.md
+++ b/sycl/doc/SYCL_compiler_and_runtime_design.md
@@ -291,17 +291,28 @@ produced by OpenCL C front-end compiler.
 It's a regular function, which can conflict with user code produced from C++
 source.
 
-
-SYCL compiler uses solution developed for OpenCL C++ compiler prototype:
+SYCL compiler uses modified solution developed for OpenCL C++ compiler
+prototype:
 
 - Compiler: https://github.com/KhronosGroup/SPIR/tree/spirv-1.1
 - Headers: https://github.com/KhronosGroup/libclcxx
 
-SPIR-V types and operations that do not have LLVM equivalents are **declared**
+Our solution re-uses OpenCL data types like sampler, event, image types, etc,
+but we use different spelling to avoid potential conflicts with C++ code.
+Spelling convention for the OpenCL types enabled in SYCL mode is:
+
+```
+__ocl_<OpenCL_type_name> // e.g. __ocl_sampler_t, __ocl_event_t
+```
+
+Operations using OpenCL types use special naming convention described in this
+[document](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/master/docs/SPIRVRepresentationInLLVM.rst).
+This solution allows us avoid SYCL specialization in SPIR-V translator and
+leverage clang infrastructure developed for OpenCL types.
+
+SPIR-V operations that do not have LLVM equivalents are **declared**
 (but not defined) in the headers and satisfy following requirements:
 
-- the type must be pre-declared as a C++ class in `cl::__spirv` namespace
-- the type must not have actual definition in C++ program
 - the operation is expressed in C++ as `extern` function not throwing C++
   exceptions
 - the operation must not have the actual definition in C++ program
@@ -310,41 +321,16 @@ For example, the following C++ code is successfully recognized and translated
 into SPIR-V operation `OpGroupAsyncCopy`:
 
 ```C++
-namespace cl {
-  namespace __spirv {
-  // This class does not have definition, it is only predeclared here.
-  // The pointers to this class objects can be passed to or returned from
-  // SPIR-V built-in functions. Only in such cases the class is recognized
-  // as SPIR-V type OpTypeEvent.
-  class OpTypeEvent;
+template <typename dataT>
+extern __ocl_event_t
+__spirv_OpGroupAsyncCopy(int32_t Scope, __local dataT *Dest,
+                         __global dataT *Src, size_t NumElements,
+                         size_t Stride, __ocl_event_t E) noexcept;
 
-  template <typename dataT>
-  extern OpTypeEvent *OpGroupAsyncCopy(int32_t Scope, __local dataT *Dest,
-                                       __global dataT *Src, size_t NumElements,
-                                       size_t Stride, OpTypeEvent *E) noexcept;
-  } // namespace __spirv
-} // namespace cl
-
-cl::__spirv::OpTypeEvent *e =
-    cl::__spirv::OpGroupAsyncCopy<dataT>(cl::__spirv::Scope::Workgroup,
-                                         dst, src, numElements, 1, 0);
+__ocl_event_t e =
+  __spirv_OpGroupAsyncCopy(cl::__spirv::Scope::Workgroup,
+                           dst, src, numElements, 1, E);
 ```
-
-OpenCL C++ compiler uses a special module pass in clang that transforms the
-names of C++ classes, globals and functions from the namespace `cl::__spirv::`
-to
-["SPIR-V representation in LLVM IR"](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/master/docs/SPIRVRepresentationInLLVM.rst)
-which is recognized by the LLVM IR to SPIR-V translator.
-
-In the OpenCL C++ prototype project the pass is located at the directory:
-`lib/CodeGen/OclCxxRewrite`.  The file with the pass is:
-`lib/CodeGen/OclCxxRewrite/BifNameReflower.cpp`.  The other files in
-`lib/CodeGen/OclCxxRewrite` are utility files implementing Itanium demangler
-and other helping functionality.
-
-That LLVM module pass has been ported from OpenCL C++ prototype to the SYCL
-compiler as is. It made possible using simple declarations of C++ classes and
-external functions as if they were the SPIR-V specific types and operations.
 
 #### Some details and agreements on using SPIR-V special types and operations
 

--- a/sycl/include/CL/sycl/detail/sampler_impl.hpp
+++ b/sycl/include/CL/sycl/detail/sampler_impl.hpp
@@ -27,15 +27,12 @@ public:
   __spirv::OpTypeSampler *m_Sampler;
   sampler_impl(__spirv::OpTypeSampler *Sampler) : m_Sampler(Sampler) {}
 #else
-  cl_sampler m_Sampler = nullptr;
-  context m_SyclContext;
   std::unordered_map<context, cl_sampler> m_contextToSampler;
 
 private:
   coordinate_normalization_mode m_CoordNormMode;
   addressing_mode m_AddrMode;
   filtering_mode m_FiltMode;
-  bool m_ReleaseSampler;
 
 public:
   sampler_impl(coordinate_normalization_mode normalizationMode,

--- a/sycl/include/CL/sycl/detail/sampler_impl.hpp
+++ b/sycl/include/CL/sycl/detail/sampler_impl.hpp
@@ -24,8 +24,8 @@ namespace detail {
 class sampler_impl {
 public:
 #ifdef __SYCL_DEVICE_ONLY__
-  __spirv::OpTypeSampler *m_Sampler;
-  sampler_impl(__spirv::OpTypeSampler *Sampler) : m_Sampler(Sampler) {}
+  __ocl_sampler_t m_Sampler;
+  sampler_impl(__ocl_sampler_t Sampler) : m_Sampler(Sampler) {}
 #else
   std::unordered_map<context, cl_sampler> m_contextToSampler;
 

--- a/sycl/include/CL/sycl/handler2.hpp
+++ b/sycl/include/CL/sycl/handler2.hpp
@@ -284,8 +284,6 @@ private:
         break;
       }
       case detail::kernel_param_kind_t::kind_sampler: {
-
-        sampler *SamplerPtr = (sampler *)Ptr;
         MArgs.emplace_back(
             detail::ArgDesc(detail::kernel_param_kind_t::kind_sampler, Ptr,
                             sizeof(sampler), NextArgId));

--- a/sycl/include/CL/sycl/sampler.hpp
+++ b/sycl/include/CL/sycl/sampler.hpp
@@ -60,7 +60,7 @@ public:
 private:
 #ifdef __SYCL_DEVICE_ONLY__
   detail::sampler_impl impl;
-  void __init(__spirv::OpTypeSampler *Sampler) { impl.m_Sampler = Sampler; }
+  void __init(__ocl_sampler_t Sampler) { impl.m_Sampler = Sampler; }
   char padding[sizeof(std::shared_ptr<detail::sampler_impl>) - sizeof(impl)];
 #else
   std::shared_ptr<detail::sampler_impl> impl;

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -46,7 +46,7 @@ cl_sampler sampler_impl::getOrCreateSampler(const context &Context) {
   if (m_contextToSampler[Context])
     return m_contextToSampler[Context];
 
-#ifdef CL_TARGET_OPENCL_VERSION > 120
+#if CL_TARGET_OPENCL_VERSION > 120
   const cl_sampler_properties sprops[] = {
       CL_SAMPLER_NORMALIZED_COORDS,
       static_cast<cl_sampler_properties>(m_CoordNormMode),

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -379,18 +379,21 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
         break;
       }
     AllocaCommand *AllocaCmd = findAllocaForReq(Record, Req, Queue);
-    UpdateLeafs(Deps, Record, Req);
 
     for (Command *Dep : Deps) {
       NewCmd->addDep(DepDesc{Dep, Req, AllocaCmd});
-      Dep->addUser(NewCmd.get());
     }
   }
 
-  for (Requirement *Req : Reqs) {
+  // Set new command as user for dependencies and update leafs.
+  for (DepDesc &Dep : NewCmd->MDeps) {
+    Dep.MDepCommand->addUser(NewCmd.get());
+    Requirement *Req = Dep.MReq;
     MemObjRecord *Record = getMemObjRecord(Req->MSYCLMemObj);
+    UpdateLeafs({Dep.MDepCommand}, Record, Req);
     AddNodeToLeafs(Record, NewCmd.get(), Req);
   }
+
   return NewCmd.release();
 }
 

--- a/sycl/test/sub_group/helper.hpp
+++ b/sycl/test/sub_group/helper.hpp
@@ -112,7 +112,9 @@ template <typename T> void exit_if_not_equal(T val, T ref, const char *name) {
 }
 
 template <> void exit_if_not_equal(half val, half ref, const char *name) {
-  if (std::fabs((float)val - (float)ref) > 0.01) {
+  int16_t cmp_val = reinterpret_cast<int16_t&>(val);
+  int16_t cmp_ref = reinterpret_cast<int16_t&>(ref);
+  if (std::abs(cmp_val - cmp_ref) > 1) {
     std::cout << "Unexpected result for " << name << ": " << (float)val
               << " expected value: " << (float)ref << std::endl;
     exit(1);

--- a/sycl/test/sub_group/load_store.cpp
+++ b/sycl/test/sub_group/load_store.cpp
@@ -11,8 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// XFAIL: gpu
-
 #include "helper.hpp"
 #include <CL/sycl.hpp>
 template <typename T, int N> class sycl_subgr;


### PR DESCRIPTION
This is an attempt to re-use OpenCL sampler for SYCL.

- `sampler_t` type name is replaced with `__ocl_sampler_t` to avoid
potential collisions with user types
- selectively enabled a couple of OpenCL diagnostics for this type

Notes:
- errors are reported in the SYCL headers rather than in the user's code
- some diagnostics trigger on SYCL use cases. E.g. SYCL kernel
initializes lambda members with the values from kernel arguments. This
initialization code for sampler emits errors because OpenCL allows
sampler initialization only with integer constants. Another potential
issue is the lambda object itself - captured sampler is a member of the
lambda object and OpenCL doesn't allow composite types with samplers.
SPIR-V produced from SYCL should be okay as lambda object can be removed
by standard LLVM transformation passes.

Signed-off-by: Alexey Bader <alexey.bader@intel.com>