### PR TITLE
WIP: Remove sycl address space

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -486,15 +486,12 @@ public:
   /// Returns true if the address space in these qualifiers is equal to or
   /// a superset of the address space in the argument qualifiers.
   bool isAddressSpaceSupersetOf(Qualifiers other) const {
-
-    return
-        isAddressSpaceSupersetOf(getAddressSpace(), other.getAddressSpace()) ||
-        (!hasAddressSpace() &&
-         (other.getAddressSpace() == LangAS::sycl_private ||
-          other.getAddressSpace() == LangAS::sycl_local ||
-          other.getAddressSpace() == LangAS::sycl_global ||
-          other.getAddressSpace() == LangAS::sycl_constant ||
-          other.getAddressSpace() == LangAS::sycl_generic));
+    return isAddressSpaceSupersetOf(getAddressSpace(),
+                                    other.getAddressSpace()) ||
+           (!hasAddressSpace() &&
+            (other.getAddressSpace() == LangAS::opencl_private ||
+             other.getAddressSpace() == LangAS::opencl_local ||
+             other.getAddressSpace() == LangAS::opencl_global));
   }
 
   /// Determines if these qualifiers compatibly include another set.

--- a/clang/include/clang/Basic/AddressSpaces.h
+++ b/clang/include/clang/Basic/AddressSpaces.h
@@ -42,14 +42,6 @@ enum class LangAS : unsigned {
   cuda_constant,
   cuda_shared,
 
-  sycl_global,
-  sycl_local,
-  sycl_constant,
-  sycl_private,
-  // Likely never used, but useful in the future to reserve the spot in the
-  // enum.
-  sycl_generic,
-
   // Pointer size and extension address spaces.
   ptr32_sptr,
   ptr32_uptr,

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1144,6 +1144,15 @@ def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
   let PragmaAttributeSupport = 0;
 }
 
+def SYCLIntelUsesGlobalWorkOffset : InheritableAttr {
+  let Spellings = [CXX11<"intelfpga","uses_global_work_offset">];
+  let Args = [BoolArgument<"Enabled">];
+  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Documentation = [SYCLIntelUsesGlobalWorkOffsetDocs];
+  let PragmaAttributeSupport = 0;
+}
+
 def C11NoReturn : InheritableAttr {
   let Spellings = [Keyword<"_Noreturn">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -2009,6 +2009,16 @@ device kernel, the attribute is ignored and it is not propagated to a kernel.
   }];
 }
 
+def SYCLIntelUsesGlobalWorkOffsetDocs : Documentation {
+  let Category = DocCatFunction;
+  let Heading = "uses_global_work_offset (IntelFPGA)";
+  let Content = [{
+Applies to a device function/lambda function or function call operator (of a
+function object). If 0, compiler doesn't use the global work offset values for
+the device function. Valid values are 0 and 1.
+  }];
+}
+
 def SYCLFPGAPipeDocs : Documentation {
   let Category = DocCatStmt;
   let Heading = "pipe (read_only, write_only)";

--- a/clang/include/clang/Basic/AttributeCommonInfo.h
+++ b/clang/include/clang/Basic/AttributeCommonInfo.h
@@ -158,7 +158,8 @@ public:
         (ParsedAttr == AT_IntelReqdSubGroupSize && isCXX11Attribute()) ||
         ParsedAttr == AT_SYCLIntelNumSimdWorkItems ||
         ParsedAttr == AT_SYCLIntelMaxWorkGroupSize ||
-        ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim)
+        ParsedAttr == AT_SYCLIntelMaxGlobalWorkDim ||
+        ParsedAttr == AT_SYCLIntelUsesGlobalWorkOffset)
       return true;
 
     return false;

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -637,8 +637,10 @@ def NSReturnsMismatch : DiagGroup<"nsreturns-mismatch">;
 def IndependentClassAttribute : DiagGroup<"IndependentClass-attribute">;
 def UnknownAttributes : DiagGroup<"unknown-attributes">;
 def IgnoredAttributes : DiagGroup<"ignored-attributes">;
+def AdjustedAttributes : DiagGroup<"adjusted-attributes">;
 def Attributes : DiagGroup<"attributes", [UnknownAttributes,
-                                          IgnoredAttributes]>;
+                                          IgnoredAttributes,
+                                          AdjustedAttributes]>;
 def UnknownSanitizers : DiagGroup<"unknown-sanitizers">;
 def UnnamedTypeTemplateArgs : DiagGroup<"unnamed-type-template-args",
                                         [CXX98CompatUnnamedTypeTemplateArgs]>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10324,6 +10324,9 @@ def err_sycl_x_y_z_arguments_must_be_one : Error<
   "%0 X-, Y- and Z- sizes must be 1 when %1 attribute is used with value 0">;
 def err_intel_attribute_argument_is_not_in_range: Error<
    "The value of %0 attribute must be in range from 0 to 3">;
+def warn_boolean_attribute_argument_is_not_valid: Warning<
+   "The value of %0 attribute should be 0 or 1. Adjusted to 1">,
+   InGroup<AdjustedAttributes>;
 def err_sycl_attibute_cannot_be_applied_here
     : Error<"%0 attribute cannot be applied to a "
             "%select{static function or function in an anonymous namespace"

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10292,8 +10292,6 @@ def err_builtin_launder_invalid_arg : Error<
   "'__builtin_launder' is not allowed">;
 
 // SYCL-specific diagnostics
-def err_sycl_attribute_address_space_invalid : Error<
-  "address space is outside the valid range of values">;
 def err_sycl_kernel_name_class_not_top_level : Error<
  "kernel name class and its template argument classes' declarations can only "
  "nest in a namespace: %0">;

--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -534,24 +534,6 @@ public:
     }
   }
 
-  /// If this is an OpenCL addr space attribute returns its SYCL representation
-  /// in LangAS, otherwise returns default addr space.
-  LangAS asSYCLLangAS() const {
-    switch (getKind()) {
-    case ParsedAttr::AT_OpenCLConstantAddressSpace:
-      return LangAS::sycl_constant;
-    case ParsedAttr::AT_OpenCLGlobalAddressSpace:
-      return LangAS::sycl_global;
-    case ParsedAttr::AT_OpenCLLocalAddressSpace:
-      return LangAS::sycl_local;
-    case ParsedAttr::AT_OpenCLPrivateAddressSpace:
-      return LangAS::sycl_private;
-    case ParsedAttr::AT_OpenCLGenericAddressSpace:
-    default:
-      return LangAS::Default;
-    }
-  }
-
   AttributeCommonInfo::Kind getKind() const { return getParsedKind(); }
 };
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -12079,11 +12079,33 @@ public:
     KernelCallDllimportFunction,
     KernelCallVariadicFunction
  };
-  DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
   bool isKnownGoodSYCLDecl(const Decl *D);
   void ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc, MangleContext &MC);
   void MarkDevice(void);
-  bool CheckSYCLCall(SourceLocation Loc, FunctionDecl *Callee);
+
+  /// Creates a DeviceDiagBuilder that emits the diagnostic if the current
+  /// context is "used as device code".
+  ///
+  /// - If CurLexicalContext is a kernel function or it is known that the
+  ///   function will be emitted for the device, emits the diagnostics
+  ///   immediately.
+  /// - If CurLexicalContext is a function and we are compiling
+  ///   for the device, but we don't know that this function will be codegen'ed
+  ///   for devive yet, creates a diagnostic which is emitted if and when we
+  ///   realize that the function will be codegen'ed.
+  ///
+  /// Example usage:
+  ///
+  /// Variables with thread storage duration are not allowed to be used in SYCL
+  /// device code
+  /// if (getLangOpts().SYCLIsDevice)
+  ///   SYCLDiagIfDeviceCode(Loc, diag::err_thread_unsupported);
+  DeviceDiagBuilder SYCLDiagIfDeviceCode(SourceLocation Loc, unsigned DiagID);
+
+  /// Checks if Callee function is a device function and emits
+  /// diagnostics if it is known that it is a device function, adds this
+  /// function to the DeviceCallGraph otherwise.
+  void checkSYCLDeviceFunction(SourceLocation Loc, FunctionDecl *Callee);
 };
 
 /// RAII object that enters a new expression evaluation context.

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -836,11 +836,6 @@ static const LangASMap *getAddressSpaceMap(const TargetInfo &T,
         5, // cuda_device
         6, // cuda_constant
         7, // cuda_shared
-        1, // sycl_global
-        3, // sycl_local
-        2, // sycl_constant
-        0, // sycl_private
-        4, // sycl_generic
         8, // ptr32_sptr
         9, // ptr32_uptr
         10 // ptr64

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -1792,16 +1792,12 @@ std::string Qualifiers::getAddrSpaceAsString(LangAS AS) {
   case LangAS::Default:
     return "";
   case LangAS::opencl_global:
-  case LangAS::sycl_global:
     return "__global";
   case LangAS::opencl_local:
-  case LangAS::sycl_local:
     return "__local";
   case LangAS::opencl_private:
-  case LangAS::sycl_private:
     return "__private";
   case LangAS::opencl_constant:
-  case LangAS::sycl_constant:
     return "__constant";
   case LangAS::opencl_generic:
     return "__generic";

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -48,11 +48,6 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsGenMap = {
     Global,   // cuda_device
     Constant, // cuda_constant
     Local,    // cuda_shared
-    Global,   // sycl_global
-    Local,    // sycl_local
-    Constant, // sycl_constant
-    Private,  // sycl_private
-    Generic,  // sycl_generic
     Generic,  // ptr32_sptr
     Generic,  // ptr32_uptr
     Generic   // ptr64
@@ -68,11 +63,6 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
     Global,   // cuda_device
     Constant, // cuda_constant
     Local,    // cuda_shared
-    Global,   // sycl_global
-    Local,    // sycl_local
-    Constant, // sycl_constant
-    Private,  // sycl_private
-    Generic,  // sycl_generic
     Generic,  // ptr32_sptr
     Generic,  // ptr32_uptr
     Generic   // ptr64

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -33,12 +33,6 @@ static const unsigned NVPTXAddrSpaceMap[] = {
     1, // cuda_device
     4, // cuda_constant
     3, // cuda_shared
-    1, // sycl_global
-    3, // sycl_local
-    4, // sycl_constant
-    0, // sycl_private
-    // FIXME: generic has to be added to the target
-    0, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0  // ptr64

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -33,11 +33,6 @@ static const unsigned SPIRAddrSpaceMap[] = {
     0, // cuda_device
     0, // cuda_constant
     0, // cuda_shared
-    1, // sycl_global
-    3, // sycl_local
-    2, // sycl_constant
-    0, // sycl_private
-    4, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0  // ptr64
@@ -53,11 +48,6 @@ static const unsigned SYCLAddrSpaceMap[] = {
     0, // cuda_device
     0, // cuda_constant
     0, // cuda_shared
-    1, // sycl_global
-    3, // sycl_local
-    2, // sycl_constant
-    0, // sycl_private
-    4, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0  // ptr64
@@ -70,11 +60,9 @@ public:
     TLSSupported = false;
     VLASupported = false;
     LongWidth = LongAlign = 64;
-    if (Triple.getEnvironment() == llvm::Triple::SYCLDevice) {
-      AddrSpaceMap = &SYCLAddrSpaceMap;
-    } else {
-      AddrSpaceMap = &SPIRAddrSpaceMap;
-    }
+    AddrSpaceMap = (Triple.getEnvironment() == llvm::Triple::SYCLDevice)
+                       ? &SYCLAddrSpaceMap
+                       : &SPIRAddrSpaceMap;
     UseAddrSpaceMapMangling = true;
     HasLegalHalfType = true;
     HasFloat16 = true;

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -40,12 +40,6 @@ static const unsigned TCEOpenCLAddrSpaceMap[] = {
     0, // cuda_device
     0, // cuda_constant
     0, // cuda_shared
-    3, // sycl_global
-    4, // sycl_local
-    5, // sycl_constant
-    0, // sycl_private
-    // FIXME: generic has to be added to the target
-    0, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0, // ptr64

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -32,11 +32,6 @@ static const unsigned X86AddrSpaceMap[] = {
     0,   // cuda_device
     0,   // cuda_constant
     0,   // cuda_shared
-    0,   // sycl_global
-    0,   // sycl_local
-    0,   // sycl_constant
-    0,   // sycl_private
-    0,   // sycl_generic
     270, // ptr32_sptr
     271, // ptr32_uptr
     272  // ptr64

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -668,6 +668,17 @@ void CodeGenFunction::EmitOpenCLKernelMetadata(const FunctionDecl *FD,
     Fn->setMetadata("max_global_work_dim",
                     llvm::MDNode::get(Context, AttrMDArgs));
   }
+
+  if (const SYCLIntelUsesGlobalWorkOffsetAttr *A =
+          FD->getAttr<SYCLIntelUsesGlobalWorkOffsetAttr>()) {
+    bool IsEnabled = A->getEnabled();
+    if (!IsEnabled) {
+      llvm::Metadata *AttrMDArgs[] = {
+          llvm::ConstantAsMetadata::get(Builder.getInt32(IsEnabled))};
+      Fn->setMetadata("uses_global_work_offset",
+                      llvm::MDNode::get(Context, AttrMDArgs));
+    }
+  }
 }
 
 /// Determine whether the function F ends with a return stmt.

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1610,6 +1610,9 @@ Sema::DeviceDiagBuilder Sema::targetDiag(SourceLocation Loc, unsigned DiagID) {
   if (getLangOpts().CUDA)
     return getLangOpts().CUDAIsDevice ? CUDADiagIfDeviceCode(Loc, DiagID)
                                       : CUDADiagIfHostCode(Loc, DiagID);
+  // TODO: analyze which usages of targetDiag could be reused for SYCL.
+  // if (getLangOpts().SYCLIsDevice)
+  //   return SYCLDiagIfDeviceCode(Loc, DiagID);
   return DeviceDiagBuilder(DeviceDiagBuilder::K_Immediate, Loc, DiagID,
                            getCurFunctionDecl(), *this);
 }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5166,6 +5166,26 @@ static bool checkForDuplicateAttribute(Sema &S, Decl *D,
   return false;
 }
 
+static void handleUsesGlobalWorkOffsetAttr(Sema &S, Decl *D,
+                                           const ParsedAttr &Attr) {
+  if (S.LangOpts.SYCLIsHost)
+    return;
+
+  checkForDuplicateAttribute<SYCLIntelUsesGlobalWorkOffsetAttr>(S, D, Attr);
+
+  uint32_t Enabled;
+  const Expr *E = Attr.getArgAsExpr(0);
+  if (!checkUInt32Argument(S, Attr, E, Enabled, 0,
+                           /*StrictlyUnsigned=*/true))
+    return;
+  if (Enabled > 1)
+    S.Diag(Attr.getLoc(), diag::warn_boolean_attribute_argument_is_not_valid)
+        << Attr;
+
+  D->addAttr(::new (S.Context)
+                 SYCLIntelUsesGlobalWorkOffsetAttr(S.Context, Attr, Enabled));
+}
+
 /// Handle the [[intelfpga::doublepump]] and [[intelfpga::singlepump]] attributes.
 /// One but not both can be specified
 /// Both are incompatible with the __register__ attribute.
@@ -7599,6 +7619,9 @@ static void ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D,
   case ParsedAttr::AT_SYCLIntelMaxGlobalWorkDim:
     handleMaxGlobalWorkDimAttr(S, D, AL);
     break;
+  case ParsedAttr::AT_SYCLIntelUsesGlobalWorkOffset:
+    handleUsesGlobalWorkOffsetAttr(S, D, AL);
+    break;
   case ParsedAttr::AT_VecTypeHint:
     handleVecTypeHint(S, D, AL);
     break;
@@ -8080,6 +8103,10 @@ void Sema::ProcessDeclAttributeList(Scope *S, Decl *D,
       Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
       D->setInvalidDecl();
     } else if (const auto *A = D->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
+      Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
+      D->setInvalidDecl();
+    } else if (const auto *A =
+                   D->getAttr<SYCLIntelUsesGlobalWorkOffsetAttr>()) {
       Diag(D->getLocation(), diag::err_opencl_kernel_attr) << A;
       D->setInvalidDecl();
     } else if (const auto *A = D->getAttr<VecTypeHintAttr>()) {

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -14644,7 +14644,7 @@ Sema::BuildCXXConstructExpr(SourceLocation ConstructLoc, QualType DeclInitType,
   if (getLangOpts().CUDA && !CheckCUDACall(ConstructLoc, Constructor))
     return ExprError();
   if (getLangOpts().SYCLIsDevice)
-    CheckSYCLCall(ConstructLoc, Constructor);
+    checkSYCLDeviceFunction(ConstructLoc, Constructor);
 
   return CXXConstructExpr::Create(
       Context, DeclInitType, ConstructLoc, Constructor, Elidable,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -269,7 +269,7 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
       return true;
 
     if (getLangOpts().SYCLIsDevice)
-      CheckSYCLCall(Loc, FD);
+      checkSYCLDeviceFunction(Loc, FD);
   }
 
   if (auto *MD = dyn_cast<CXXMethodDecl>(D)) {
@@ -15649,7 +15649,7 @@ void Sema::MarkFunctionReferenced(SourceLocation Loc, FunctionDecl *Func,
   if (getLangOpts().CUDA)
     CheckCUDACall(Loc, Func);
   if (getLangOpts().SYCLIsDevice)
-    CheckSYCLCall(Loc, Func);
+    checkSYCLDeviceFunction(Loc, Func);
 
   // If we need a definition, try to create one.
   if (NeedDefinition && !Func->getBody()) {
@@ -17219,15 +17219,7 @@ namespace {
     }
 
     void VisitCXXNewExpr(CXXNewExpr *E) {
-      FunctionDecl *FD = E->getOperatorNew();
-      if (FD && S.getLangOpts().SYCLIsDevice) {
-        if (FD->isReplaceableGlobalAllocationFunction())
-          S.SYCLDiagIfDeviceCode(E->getExprLoc(), diag::err_sycl_restrict)
-              << S.KernelAllocateStorage;
-        else if (FunctionDecl *Def = FD->getDefinition())
-          S.CheckSYCLCall(E->getExprLoc(), Def);
-      }
-      if (FD)
+      if (E->getOperatorNew())
         S.MarkFunctionReferenced(E->getBeginLoc(), E->getOperatorNew());
       if (E->getOperatorDelete())
         S.MarkFunctionReferenced(E->getBeginLoc(), E->getOperatorDelete());

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2171,16 +2171,15 @@ Sema::BuildCXXNew(SourceRange Range, bool UseGlobal,
     if (DiagnoseUseOfDecl(OperatorNew, StartLoc))
       return ExprError();
     MarkFunctionReferenced(StartLoc, OperatorNew);
-    if (getLangOpts().SYCLIsDevice) {
-      CheckSYCLCall(StartLoc, OperatorNew);
-    }
+    if (getLangOpts().SYCLIsDevice &&
+        OperatorNew->isReplaceableGlobalAllocationFunction())
+      SYCLDiagIfDeviceCode(StartLoc, diag::err_sycl_restrict)
+          << KernelAllocateStorage;
   }
   if (OperatorDelete) {
     if (DiagnoseUseOfDecl(OperatorDelete, StartLoc))
       return ExprError();
     MarkFunctionReferenced(StartLoc, OperatorDelete);
-    if (getLangOpts().SYCLIsDevice)
-      CheckSYCLCall(StartLoc, OperatorDelete);
   }
 
   return CXXNewExpr::Create(Context, UseGlobal, OperatorNew, OperatorDelete,

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -12916,8 +12916,6 @@ Sema::CreateOverloadedUnaryOp(SourceLocation OpLoc, UnaryOperatorKind Opc,
                             FnDecl->getType()->castAs<FunctionProtoType>()))
         return ExprError();
 
-      if (getLangOpts().SYCLIsDevice)
-        CheckSYCLCall(OpLoc, FnDecl);
       return MaybeBindToTemporary(TheCall);
     } else {
       // We matched a built-in operator. Convert the arguments, then
@@ -13270,8 +13268,6 @@ ExprResult Sema::CreateOverloadedBinOp(SourceLocation OpLoc,
                   isa<CXXMethodDecl>(FnDecl), OpLoc, TheCall->getSourceRange(),
                   VariadicDoesNotApply);
 
-        if (getLangOpts().SYCLIsDevice)
-          CheckSYCLCall(OpLoc, FnDecl);
         ExprResult R = MaybeBindToTemporary(TheCall);
         if (R.isInvalid())
           return ExprError();
@@ -13633,8 +13629,6 @@ Sema::CreateOverloadedArraySubscriptExpr(SourceLocation LLoc,
                               Method->getType()->castAs<FunctionProtoType>()))
           return ExprError();
 
-        if (getLangOpts().SYCLIsDevice)
-          CheckSYCLCall(RLoc, FnDecl);
         return MaybeBindToTemporary(TheCall);
       } else {
         // We matched a built-in operator. Convert the arguments, then

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -469,6 +469,14 @@ public:
           FD->dropAttr<SYCLIntelMaxGlobalWorkDimAttr>();
         }
       }
+      if (auto *A = FD->getAttr<SYCLIntelUsesGlobalWorkOffsetAttr>()) {
+        if (ParentFD == SYCLKernel) {
+          Attrs.insert(A);
+        } else {
+          SemaRef.Diag(A->getLocation(), diag::warn_attribute_ignored) << A;
+          FD->dropAttr<SYCLIntelUsesGlobalWorkOffsetAttr>();
+        }
+      }
 
       // TODO: vec_len_hint should be handled here
 
@@ -1359,7 +1367,8 @@ void Sema::MarkDevice(void) {
         case attr::Kind::SYCLIntelKernelArgsRestrict:
         case attr::Kind::SYCLIntelNumSimdWorkItems:
         case attr::Kind::SYCLIntelMaxGlobalWorkDim:
-        case attr::Kind::SYCLIntelMaxWorkGroupSize: {
+        case attr::Kind::SYCLIntelMaxWorkGroupSize:
+        case attr::Kind::SYCLIntelUsesGlobalWorkOffset: {
           SYCLKernel->addAttr(A);
           break;
         }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -359,10 +359,7 @@ public:
     // new operator and any user-defined overloads that
     // do not allocate storage are permitted.
     if (FunctionDecl *FD = E->getOperatorNew()) {
-      if (FD->isReplaceableGlobalAllocationFunction()) {
-        SemaRef.Diag(E->getExprLoc(), diag::err_sycl_restrict)
-            << Sema::KernelAllocateStorage;
-      } else if (FunctionDecl *Def = FD->getDefinition()) {
+      if (FunctionDecl *Def = FD->getDefinition()) {
         if (!Def->hasAttr<SYCLDeviceAttr>()) {
           Def->addAttr(SYCLDeviceAttr::CreateImplicit(SemaRef.Context));
           SemaRef.addSyclDeviceDecl(Def);
@@ -529,8 +526,7 @@ private:
         if (!CheckSYCLType(Field->getType(), Field->getSourceRange(),
                            Visited)) {
           if (SemaRef.getLangOpts().SYCLIsDevice)
-            SemaRef.SYCLDiagIfDeviceCode(Loc.getBegin(),
-                                         diag::note_sycl_used_here);
+            SemaRef.Diag(Loc.getBegin(), diag::note_sycl_used_here);
           return false;
         }
       }
@@ -539,8 +535,7 @@ private:
         if (!CheckSYCLType(Field->getType(), Field->getSourceRange(),
                            Visited)) {
           if (SemaRef.getLangOpts().SYCLIsDevice)
-            SemaRef.SYCLDiagIfDeviceCode(Loc.getBegin(),
-                                         diag::note_sycl_used_here);
+            SemaRef.Diag(Loc.getBegin(), diag::note_sycl_used_here);
           return false;
         }
       }
@@ -1399,8 +1394,7 @@ void Sema::MarkDevice(void) {
 
 // Do we know that we will eventually codegen the given function?
 static bool isKnownEmitted(Sema &S, FunctionDecl *FD) {
-  if (!FD)
-    return true; // Seen in LIT testing
+  assert(FD && "Given function may not be null.");
 
   if (FD->hasAttr<SYCLDeviceAttr>() || FD->hasAttr<SYCLKernelAttr>())
     return true;
@@ -1416,16 +1410,16 @@ Sema::DeviceDiagBuilder Sema::SYCLDiagIfDeviceCode(SourceLocation Loc,
          "Should only be called during SYCL compilation");
   FunctionDecl *FD = dyn_cast<FunctionDecl>(getCurLexicalContext());
   DeviceDiagBuilder::Kind DiagKind = [this, FD] {
-    if (ConstructingOpenCLKernel)
+    if (ConstructingOpenCLKernel || !FD)
       return DeviceDiagBuilder::K_Nop;
-    else if (isKnownEmitted(*this, FD))
+    if (isKnownEmitted(*this, FD))
       return DeviceDiagBuilder::K_ImmediateWithCallStack;
     return DeviceDiagBuilder::K_Deferred;
   }();
   return DeviceDiagBuilder(DiagKind, Loc, DiagID, FD, *this);
 }
 
-bool Sema::CheckSYCLCall(SourceLocation Loc, FunctionDecl *Callee) {
+void Sema::checkSYCLDeviceFunction(SourceLocation Loc, FunctionDecl *Callee) {
   assert(Callee && "Callee may not be null.");
   FunctionDecl *Caller = dyn_cast<FunctionDecl>(getCurLexicalContext());
 
@@ -1435,7 +1429,6 @@ bool Sema::CheckSYCLCall(SourceLocation Loc, FunctionDecl *Callee) {
     markKnownEmitted(*this, Caller, Callee, Loc, isKnownEmitted);
   else if (Caller)
     DeviceCallGraph[Caller].insert({Callee, Loc});
-  return true;
 }
 
 // -----------------------------------------------------------------------------

--- a/clang/lib/Sema/SemaStmtAsm.cpp
+++ b/clang/lib/Sema/SemaStmtAsm.cpp
@@ -259,12 +259,11 @@ StmtResult Sema::ActOnGCCAsmStmt(SourceLocation AsmLoc, bool IsSimple,
   // Skip all the checks if we are compiling SYCL device code, but the function
   // is not marked to be used on device, this code won't be codegen'ed anyway.
   if (getLangOpts().SYCLIsDevice) {
-    SYCLDiagIfDeviceCode(AsmLoc, diag::err_sycl_restrict)
-        << KernelUseAssembly;
+    SYCLDiagIfDeviceCode(AsmLoc, diag::err_sycl_restrict) << KernelUseAssembly;
     return new (Context)
-      GCCAsmStmt(Context, AsmLoc, IsSimple, IsVolatile, NumOutputs,
-                 NumInputs, Names, Constraints, Exprs.data(), AsmString,
-                 NumClobbers, Clobbers, NumLabels, RParenLoc);
+        GCCAsmStmt(Context, AsmLoc, IsSimple, IsVolatile, NumOutputs, NumInputs,
+                   Names, Constraints, Exprs.data(), AsmString, NumClobbers,
+                   Clobbers, NumLabels, RParenLoc);
   }
 
   FunctionDecl *FD = dyn_cast<FunctionDecl>(getCurLexicalContext());

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -1500,11 +1500,15 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
       Result = Context.DoubleTy;
     break;
   case DeclSpec::TST_float128:
-    if (!S.Context.getTargetInfo().hasFloat128Type() && 
-        !S.getLangOpts().SYCLIsDevice &&
-        !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
+    if (!S.Context.getTargetInfo().hasFloat128Type() &&
+        S.getLangOpts().SYCLIsDevice)
+      S.SYCLDiagIfDeviceCode(DS.getTypeSpecTypeLoc(),
+                             diag::err_type_unsupported)
+          << "__float128";
+    else if (!S.Context.getTargetInfo().hasFloat128Type() &&
+             !(S.getLangOpts().OpenMP && S.getLangOpts().OpenMPIsDevice))
       S.Diag(DS.getTypeSpecTypeLoc(), diag::err_type_unsupported)
-        << "__float128";
+          << "__float128";
     Result = Context.Float128Ty;
     break;
   case DeclSpec::TST_bool: Result = Context.BoolTy; break; // _Bool or bool

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -9,7 +9,7 @@ void foo(int * Data) {}
 // CHECK-DAG: define spir_func void @[[RAW_PTR:[a-zA-Z0-9_]+]](i32 addrspace(4)* %
 void foo2(int * Data) {}
 // CHECK-DAG: define spir_func void @[[RAW_PTR2:[a-zA-Z0-9_]+]](i32 addrspace(4)* %
-void foo(__attribute__((address_space(3))) int * Data) {}
+void foo(__attribute__((opencl_local)) int * Data) {}
 // CHECK-DAG: define spir_func void [[LOC_PTR:@[a-zA-Z0-9_]+]](i32 addrspace(3)* %
 
 template<typename T>
@@ -18,12 +18,11 @@ void tmpl(T t){}
 
 void usages() {
   // CHECK-DAG: [[GLOB:%[a-zA-Z0-9]+]] = alloca i32 addrspace(1)*
-  __attribute__((address_space(1))) int *GLOB;
+  __attribute__((opencl_global)) int *GLOB;
   // CHECK-DAG: [[LOC:%[a-zA-Z0-9]+]] = alloca i32 addrspace(3)*
   __attribute__((opencl_local)) int *LOC;
   // CHECK-DAG: [[NoAS:%[a-zA-Z0-9]+]] = alloca i32 addrspace(4)*
   int *NoAS;
-
   // CHECK-DAG: [[PRIV:%[a-zA-Z0-9]+]] = alloca i32*
   __attribute__((opencl_private)) int *PRIV;
 
@@ -94,57 +93,23 @@ void usages() {
 // CHECK-DAG: define linkonce_odr spir_func void [[GEN_TMPL]](i32 addrspace(4)* %
 
 void usages2() {
-  __attribute__((address_space(0))) int *PRIV_NUM;
-  // CHECK-DAG: [[PRIV_NUM:%[a-zA-Z0-9_]+]] = alloca i32*
-  __attribute__((address_space(0))) int *PRIV_NUM2;
-  // CHECK-DAG: [[PRIV_NUM2:%[a-zA-Z0-9_]+]] = alloca i32*
   __attribute__((opencl_private)) int *PRIV;
   // CHECK-DAG: [[PRIV:%[a-zA-Z0-9_]+]] = alloca i32*
-  __attribute__((address_space(1))) int *GLOB_NUM;
-  // CHECK-DAG: [[GLOB_NUM:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(1)*
   __attribute__((opencl_global)) int *GLOB;
   // CHECK-DAG: [[GLOB:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(1)*
-  __attribute__((address_space(2))) int *CONST_NUM;
-  // CHECK-DAG: [[CONST_NUM:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(2)*
   __attribute__((opencl_constant)) int *CONST;
   // CHECK-DAG: [[CONST:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(2)*
-  __attribute__((address_space(3))) int *LOCAL_NUM;
-  // CHECK-DAG: [[LOCAL_NUM:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(3)*
   __attribute__((opencl_local)) int *LOCAL;
   // CHECK-DAG: [[LOCAL:%[a-zA-Z0-9_]+]] = alloca i32 addrspace(3)*
 
-  bar(*PRIV_NUM);
-  // CHECK-DAG: [[PRIV_NUM_LOAD:%[a-zA-Z0-9]+]] = load i32*, i32** [[PRIV_NUM]]
-  // CHECK-DAG: [[PRIV_NUM_ASCAST:%[a-zA-Z0-9]+]] = addrspacecast i32* [[PRIV_NUM_LOAD]] to i32 addrspace(4)*
-  // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* dereferenceable(4) [[PRIV_NUM_ASCAST]])
-  bar(*PRIV_NUM2);
-  // CHECK-DAG: [[PRIV_NUM2_LOAD:%[a-zA-Z0-9]+]] = load i32*, i32** [[PRIV_NUM2]]
-  // CHECK-DAG: [[PRIV_NUM2_ASCAST:%[a-zA-Z0-9]+]] = addrspacecast i32* [[PRIV_NUM2_LOAD]] to i32 addrspace(4)*
-  // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* dereferenceable(4) [[PRIV_NUM2_ASCAST]])
   bar(*PRIV);
   // CHECK-DAG: [[PRIV_LOAD:%[a-zA-Z0-9]+]] = load i32*, i32** [[PRIV]]
   // CHECK-DAG: [[PRIV_ASCAST:%[a-zA-Z0-9]+]] = addrspacecast i32* [[PRIV_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* dereferenceable(4) [[PRIV_ASCAST]])
-  bar(*GLOB_NUM);
-  // CHECK-DAG: [[GLOB_NUM_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(1)*, i32 addrspace(1)** [[GLOB_NUM]]
-  // CHECK-DAG: [[GLOB_NUM_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(1)* [[GLOB_NUM_LOAD]] to i32 addrspace(4)*
-  // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* dereferenceable(4) [[GLOB_NUM_CAST]])
   bar(*GLOB);
   // CHECK-DAG: [[GLOB_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(1)*, i32 addrspace(1)** [[GLOB]]
   // CHECK-DAG: [[GLOB_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(1)* [[GLOB_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* dereferenceable(4) [[GLOB_CAST]])
-  bar(*CONST_NUM);
-  // CHECK-DAG: [[CONST_NUM_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(2)*, i32 addrspace(2)** [[CONST_NUM]]
-  // CHECK-DAG: [[CONST_NUM_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(2)* [[CONST_NUM_LOAD]] to i32 addrspace(4)*
-  // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* dereferenceable(4) [[CONST_NUM_CAST]])
-  bar(*CONST);
-  // CHECK-DAG: [[CONST_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(2)*, i32 addrspace(2)** [[CONST]]
-  // CHECK-DAG: [[CONST_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(2)* [[CONST_LOAD]] to i32 addrspace(4)*
-  // CHECK-DAG: call spir_func void @[[RAW_REF]](i32 addrspace(4)* dereferenceable(4) [[CONST_CAST]])
-  bar2(*LOCAL_NUM);
-  // CHECK-DAG: [[LOCAL_NUM_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(3)*, i32 addrspace(3)** [[LOCAL_NUM]]
-  // CHECK-DAG: [[LOCAL_NUM_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(3)* [[LOCAL_NUM_LOAD]] to i32 addrspace(4)*
-  // CHECK-DAG: call spir_func void @[[RAW_REF2]](i32 addrspace(4)* dereferenceable(4) [[LOCAL_NUM_CAST]])
   bar2(*LOCAL);
   // CHECK-DAG: [[LOCAL_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(3)*, i32 addrspace(3)** [[LOCAL]]
   // CHECK-DAG: [[LOCAL_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(3)* [[LOCAL_LOAD]] to i32 addrspace(4)*

--- a/clang/test/CodeGenSYCL/intel-fpga-uses-global-work-offset.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-uses-global-work-offset.cpp
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -disable-llvm-passes -fsycl-is-device -emit-llvm -o - %s | FileCheck %s
+
+class Foo {
+public:
+  [[intelfpga::uses_global_work_offset(0)]] void operator()() {}
+};
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+void bar() {
+  Foo boo;
+  kernel<class kernel_name1>(boo);
+
+  kernel<class kernel_name2>(
+      []() [[intelfpga::uses_global_work_offset(0)]]{});
+
+  kernel<class kernel_name3>(
+      []() [[intelfpga::uses_global_work_offset(1)]]{});
+}
+
+// CHECK: define spir_kernel void @{{.*}}kernel_name1() {{.*}} !uses_global_work_offset ![[NUM5:[0-9]+]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name2() {{.*}} !uses_global_work_offset ![[NUM5]]
+// CHECK: define spir_kernel void @{{.*}}kernel_name3() {{.*}} ![[NUM4:[0-9]+]]
+// CHECK-NOT: ![[NUM4]]  = !{i32 1}
+// CHECK: ![[NUM5]] = !{i32 0}

--- a/clang/test/SemaOpenCLCXX/address-space-lambda.cl
+++ b/clang/test/SemaOpenCLCXX/address-space-lambda.cl
@@ -31,8 +31,8 @@ __kernel void test_qual() {
 //CHECK: |-CXXMethodDecl {{.*}} constexpr operator() 'void () const __generic'
   auto priv2 = []() __generic {};
   priv2();
-  auto priv3 = []() __global {}; //expected-note{{candidate function not viable: 'this' object is in address space '__private', but method expects object in address space '__global'}} //expected-note{{conversion candidate of type 'void (*)()'}}
-  priv3(); //expected-error{{no matching function for call to object of type}}
+  auto priv3 = []() __global {}; //ex pected-note{{candidate function not viable: 'this' object is in address space '__private', but method expects object in address space '__global'}} //ex pected-note{{conversion candidate of type 'void (*)()'}}
+  priv3(); //ex pected-error{{no matching function for call to object of type}}
 
   __constant auto const1 = []() __private{}; //expected-note{{candidate function not viable: 'this' object is in address space '__constant', but method expects object in address space '__private'}} //expected-note{{conversion candidate of type 'void (*)()'}}
   const1(); //expected-error{{no matching function for call to object of type '__constant (lambda at}}

--- a/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/SemaSYCL/address-space-parameter-conversions.cpp
@@ -13,7 +13,7 @@ void tmpl(T *t){}
 void usages() {
   __attribute__((opencl_global)) int *GLOB;
   __attribute__((opencl_private)) int *PRIV;
-  __attribute__((address_space(3))) int *LOC;
+  __attribute__((opencl_local)) int *LOC;
   int *NoAS;
 
   bar(*GLOB);
@@ -53,10 +53,6 @@ void usages() {
 
   // expected-error@+1{{address space is negative}}
   __attribute__((address_space(-1))) int *TooLow;
-  // expected-error@+1{{address space is outside the valid range of values}}
-  __attribute__((address_space(6))) int *TooHigh;
-  // expected-error@+1{{address space is outside the valid range of values}}
-  __attribute__((address_space(4))) int *TriedGeneric;
   // expected-error@+1{{unknown type name '__generic'}}
   __generic int *IsGeneric;
 

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -19,7 +19,7 @@ void bar() {
 #endif // LINUX_ASM
 }
 
-template <typename name, typename Func>
+template <typename Name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
   // expected-note@+1 {{called by 'kernel_single_task<fake_kernel, (lambda}}
   kernelFunc();

--- a/clang/test/SemaSYCL/intel-fpga-uses-global-work-offset.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-uses-global-work-offset.cpp
@@ -1,0 +1,49 @@
+// RUN: %clang_cc1 -Wno-return-type -fsycl-is-device -fcxx-exceptions -fsyntax-only -ast-dump -verify -pedantic %s | FileCheck %s
+
+struct FuncObj {
+  [[intelfpga::uses_global_work_offset(1)]] void operator()() {}
+};
+
+template <typename name, typename Func>
+void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+int main() {
+  // CHECK: SYCLIntelUsesGlobalWorkOffsetAttr{{.*}}Enabled
+  kernel<class test_kernel1>([]() {
+    FuncObj();
+  });
+
+  // CHECK: SYCLIntelUsesGlobalWorkOffsetAttr
+  // CHECK-NOT: Enabled
+  kernel<class test_kernel2>(
+      []() [[intelfpga::uses_global_work_offset(0)]]{});
+
+  // CHECK: SYCLIntelUsesGlobalWorkOffsetAttr{{.*}}Enabled
+  // expected-warning@+2{{'uses_global_work_offset' attribute should be 0 or 1. Adjusted to 1}}
+  kernel<class test_kernel3>(
+      []() [[intelfpga::uses_global_work_offset(42)]]{});
+
+  // expected-error@+2{{'uses_global_work_offset' attribute requires a non-negative integral compile time constant expression}}
+  kernel<class test_kernel4>(
+      []() [[intelfpga::uses_global_work_offset(-1)]]{});
+
+  // expected-error@+2{{'uses_global_work_offset' attribute requires parameter 0 to be an integer constant}}
+  kernel<class test_kernel5>(
+      []() [[intelfpga::uses_global_work_offset("foo")]]{});
+
+  kernel<class test_kernel6>([]() {
+    // expected-error@+1{{'uses_global_work_offset' attribute only applies to functions}}
+    [[intelfpga::uses_global_work_offset(1)]] int a;
+  });
+
+  // CHECK: SYCLIntelUsesGlobalWorkOffsetAttr{{.*}}
+  // CHECK-NOT: Enabled
+  // CHECK: SYCLIntelUsesGlobalWorkOffsetAttr{{.*}}Enabled
+  // expected-warning@+2{{attribute 'uses_global_work_offset' is already applied}}
+  kernel<class test_kernel7>(
+      []() [[intelfpga::uses_global_work_offset(0), intelfpga::uses_global_work_offset(1)]]{});
+
+  return 0;
+}

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -16,6 +16,8 @@ void kernel3(void) {
 using myFuncDef = int(int,int);
 
 void usage3(myFuncDef functionPtr) {
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  int *ip = new int;
   kernel3();
 }
 
@@ -26,14 +28,14 @@ int addInt(int n, int m) {
 template <typename name, typename Func>
   // expected-note@+1 2{{function implemented using recursion declared here}}
 __attribute__((sycl_kernel)) void kernel_single_task2(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task2}}
   kernelFunc();
-  // expected-error@+1 2{{SYCL kernel cannot allocate storage}}
-  int *ip = new int;
   // expected-error@+1 2{{SYCL kernel cannot call a recursive function}}
   kernel_single_task2<name, Func>(kernelFunc);
 }
 
 int main() {
+  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task2<class fake_kernel>([]() { usage3(  &addInt ); });
   return fib(5);
 }

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -18,6 +18,8 @@ void kernel2(void) {
 using myFuncDef = int(int,int);
 
 void usage2(myFuncDef functionPtr) {
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  int *ip = new int;
   // expected-error@+1 {{SYCL kernel cannot call a recursive function}}
   kernel2();
 }
@@ -28,12 +30,12 @@ int addInt(int n, int m) {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
-  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
-  int *ip = new int;
+  // expected-note@+1 {{called by 'kernel_single_task}}
   kernelFunc();
 }
 
 int main() {
+  // expected-note@+1 {{called by 'operator()'}}
   kernel_single_task<class fake_kernel>([]() {usage2(&addInt);});
   return fib(5);
 }

--- a/clang/test/SemaTemplate/address_space-dependent.cpp
+++ b/clang/test/SemaTemplate/address_space-dependent.cpp
@@ -43,7 +43,7 @@ void neg() {
 
 template <long int I>
 void tooBig() {
-  __attribute__((address_space(I))) int *bounds; // expected-error {{address space is larger than the maximum supported (8388590)}}
+  __attribute__((address_space(I))) int *bounds; // expected-error {{address space is larger than the maximum supported (8388595)}}
 }
 
 template <long int I>

--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -10,43 +10,35 @@
 
 #ifdef __SYCL_DEVICE_ONLY__
 
-typedef size_t size_t_vec __attribute__((ext_vector_type(3)));
-extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInGlobalSize;
-extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInGlobalInvocationId;
-extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInWorkgroupSize;
-extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInNumWorkgroups;
-extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInLocalInvocationId;
-extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInWorkgroupId;
-extern "C" const __attribute__((opencl_constant)) size_t_vec __spirv_BuiltInGlobalOffset;
+#define __SPIRV_VAR_QUALIFIERS extern "C" const __attribute__((opencl_global))
 
-#define DEFINE_INT_ID_TO_XYZ_CONVERTER(POSTFIX)                                \
-  template <int ID> static size_t get##POSTFIX();                              \
-  template <> size_t get##POSTFIX<0>() { return __spirv_BuiltIn##POSTFIX.x; }  \
-  template <> size_t get##POSTFIX<1>() { return __spirv_BuiltIn##POSTFIX.y; }  \
-  template <> size_t get##POSTFIX<2>() { return __spirv_BuiltIn##POSTFIX.z; }
+__SPIRV_VAR_QUALIFIERS uint32_t __spirv_BuiltInSubgroupSize;
+__SPIRV_VAR_QUALIFIERS uint32_t __spirv_BuiltInSubgroupMaxSize;
+__SPIRV_VAR_QUALIFIERS uint32_t __spirv_BuiltInNumSubgroups;
+__SPIRV_VAR_QUALIFIERS uint32_t __spirv_BuiltInNumEnqueuedSubgroups;
+__SPIRV_VAR_QUALIFIERS uint32_t __spirv_BuiltInSubgroupId;
+__SPIRV_VAR_QUALIFIERS uint32_t __spirv_BuiltInSubgroupLocalInvocationId;
+
+typedef size_t size_t_vec __attribute__((ext_vector_type(3)));
+__SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInGlobalSize;
+__SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInGlobalInvocationId;
+__SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInWorkgroupSize;
+__SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInNumWorkgroups;
+__SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInLocalInvocationId;
+__SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInWorkgroupId;
+__SPIRV_VAR_QUALIFIERS size_t_vec __spirv_BuiltInGlobalOffset;
+
+#undef __SPIRV_VAR_QUALIFIERS
 
 namespace __spirv {
 
-DEFINE_INT_ID_TO_XYZ_CONVERTER(GlobalSize);
-DEFINE_INT_ID_TO_XYZ_CONVERTER(GlobalInvocationId)
-DEFINE_INT_ID_TO_XYZ_CONVERTER(WorkgroupSize)
-DEFINE_INT_ID_TO_XYZ_CONVERTER(NumWorkgroups)
-DEFINE_INT_ID_TO_XYZ_CONVERTER(LocalInvocationId)
-DEFINE_INT_ID_TO_XYZ_CONVERTER(WorkgroupId)
-DEFINE_INT_ID_TO_XYZ_CONVERTER(GlobalOffset)
-
-} // namespace __spirv
-
-#undef DEFINE_INT_ID_TO_XYZ_CONVERTER
-
-extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInSubgroupSize;
-extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInSubgroupMaxSize;
-extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInNumSubgroups;
-extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInNumEnqueuedSubgroups;
-extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInSubgroupId;
-extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInSubgroupLocalInvocationId;
-
-#define DEFINE_INIT_SIZES(POSTFIX)                                             \
+// Helper function templates to initialize and get vector component from SPIR-V
+// built-in variables
+#define __SPIRV_DEFINE_INIT_AND_GET_HELPERS(POSTFIX)                           \
+  template <int ID> static size_t get##POSTFIX();                              \
+  template <> size_t get##POSTFIX<0>() { return __spirv_BuiltIn##POSTFIX.x; }  \
+  template <> size_t get##POSTFIX<1>() { return __spirv_BuiltIn##POSTFIX.y; }  \
+  template <> size_t get##POSTFIX<2>() { return __spirv_BuiltIn##POSTFIX.z; }  \
                                                                                \
   template <int Dim, class DstT> struct InitSizesST##POSTFIX;                  \
                                                                                \
@@ -68,18 +60,16 @@ extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInSubgro
     return InitSizesST##POSTFIX<Dims, DstT>::initSize();                       \
   }
 
-namespace __spirv {
+__SPIRV_DEFINE_INIT_AND_GET_HELPERS(GlobalSize);
+__SPIRV_DEFINE_INIT_AND_GET_HELPERS(GlobalInvocationId)
+__SPIRV_DEFINE_INIT_AND_GET_HELPERS(WorkgroupSize)
+__SPIRV_DEFINE_INIT_AND_GET_HELPERS(NumWorkgroups)
+__SPIRV_DEFINE_INIT_AND_GET_HELPERS(LocalInvocationId)
+__SPIRV_DEFINE_INIT_AND_GET_HELPERS(WorkgroupId)
+__SPIRV_DEFINE_INIT_AND_GET_HELPERS(GlobalOffset)
 
-DEFINE_INIT_SIZES(GlobalSize);
-DEFINE_INIT_SIZES(GlobalInvocationId)
-DEFINE_INIT_SIZES(WorkgroupSize)
-DEFINE_INIT_SIZES(NumWorkgroups)
-DEFINE_INIT_SIZES(LocalInvocationId)
-DEFINE_INIT_SIZES(WorkgroupId)
-DEFINE_INIT_SIZES(GlobalOffset)
+#undef __SPIRV_DEFINE_INIT_AND_GET_HELPERS
 
 } // namespace __spirv
-
-#undef DEFINE_INIT_SIZES
 
 #endif // __SYCL_DEVICE_ONLY__

--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -153,10 +153,11 @@ template <typename T> inline T __s_long_mad_hi(T a, T b, T c) {
 template <typename T> inline T __s_mad_sat(T a, T b, T c) {
   using UPT = typename d::make_larger<T>::type;
   UPT mul = UPT(a) * UPT(b);
+  UPT res = mul + UPT(c);
   const UPT max = d::max_v<T>();
   const UPT min = d::min_v<T>();
-  mul = std::min(std::max(mul, min), max);
-  return __s_add_sat(T(mul), c);
+  res = std::min(std::max(res, min), max);
+  return T(res);
 }
 
 template <typename T> inline T __s_long_mad_sat(T a, T b, T c) {

--- a/sycl/test/built-ins/scalar_integer.cpp
+++ b/sycl/test/built-ins/scalar_integer.cpp
@@ -287,6 +287,28 @@ int main() {
     assert(r == 0x7FFFFFFF);
   }
 
+  // mad_sat test two
+  {
+    char r(0);
+    char exp(120);
+    {
+      cl::sycl::buffer<char, 1> buf(&r, cl::sycl::range<1>(1));
+      cl::sycl::queue q;
+      q.submit([&](cl::sycl::handler &cgh) {
+        auto acc = buf.get_access<cl::sycl::access::mode::write>(cgh);
+        cgh.single_task<class kernel>([=]() {
+          signed char inputData_0(-17);
+          signed char inputData_1(-10);
+          signed char inputData_2(-50);
+          acc[0] = cl::sycl::mad_sat(inputData_0, inputData_1, inputData_2);
+        });
+      });
+    }
+    assert(r == exp); // Should return the real number of i0*i1+i2 in CPU
+                              // Only fails in vector, but passes in scalar.
+
+  }
+
   // mul_hi
   {
     s::cl_int r{ 0 };


### PR DESCRIPTION
List of issues:
1. **[Resolved]** SPIR-V built-in variables compilation issues.
```bash
include/CL/__spirv/spirv_vars.hpp:47:60: error: variable in constant address space must be initialized
extern "C" const __attribute__((opencl_constant)) uint32_t __spirv_BuiltInSubgroupLocalInvocationId;
```
If we initialize these SPIR-V variables, we get a multiple re-definition issue.

2. Allowing conversions between "default AS" and OpenCL AS breaks some of "C++ for OpenCL" tests, but not OpenCL C(!). It looks like C++ for OpenCL also relies on "default AS" rather than applying "OpenCL generic AS" for all unqualified types as OpenCL C 2.0 does. See clang/test/SemaOpenCLCXX/address-space-lambda.cl changes.